### PR TITLE
Added a (reason) to announcements

### DIFF
--- a/Mainframe.lua
+++ b/Mainframe.lua
@@ -1686,11 +1686,27 @@ function RCLootCouncil_Mainframe.award(reason)
 					if db.awardMessageChat1 ~= "NONE" then -- if we want to tell who won
 						local message = gsub(db.awardMessageText1, "&p", Ambiguate(selection[1], "short"))
 						message = gsub(message, "&i", itemRunning)
+						
+						-- If it's looted for a reason specified in the Loot History Options
+						if reason then 
+							message = gsub(message, "&r", "(" .. reason.text .. ")")
+						elseif not reason then
+							message = gsub(message, "&r", "")
+						end
+						
 						SendChatMessage(message, db.awardMessageChat1); -- then do it
 					end
 					if db.awardMessageChat2 ~= "NONE" then -- if the user is posting to 2 channels
 						local message = gsub(db.awardMessageText2, "&p", Ambiguate(selection[1], "short"))
 						message = gsub(message, "&i", itemRunning)
+						
+						-- If it's looted for a reason specified in the Loot History Options
+						if reason then 
+							message = gsub(message, "&r", "(" .. reason.text .. ")")
+						elseif not reason then
+							message = gsub(message, "&r", "")
+						end
+						
 						SendChatMessage(message, db.awardMessageChat2);
 					end
 				end

--- a/options.lua
+++ b/options.lua
@@ -328,7 +328,7 @@ function addon:OptionsTable()
 							},
 							outputDesc = {
 								order = 2,
-								name = "\nChoose wether to announce whom an item is awarded to, which message you want to announce to which channel when awarding loot, or none to toggle announcement off. You can announce in 2 channels at once.\nUse &p for the name of the player getting the loot and &i for the item awarded.",
+								name = "\nChoose wether to announce whom an item is awarded to, which message you want to announce to which channel when awarding loot, or none to toggle announcement off. You can announce in 2 channels at once.\nUse &p for the name of the player getting the loot and &i for the item awarded.\nUse &r to have (reason) tacked onto the announcement when a reason is specified in 'Other History Reasons'",
 								type = "description",
 							},
 							outputMessage = {


### PR DESCRIPTION
If I specify a reason in the Loot History (DE, Bank, Free, etc), and
loot an item to someone for that reason, the reason will now be tacked
onto the announcements.